### PR TITLE
Persist and load player decks

### DIFF
--- a/Epochs/GameModels.swift
+++ b/Epochs/GameModels.swift
@@ -7,10 +7,44 @@ public struct PlayerDeck: Codable, Hashable {
 
 public final class CollectionService: ObservableObject {
     @Published public var allCards: [Card] = []
-    @Published public var decks: [PlayerDeck] = []
-    
+    @Published public var decks: [PlayerDeck] = [] {
+        didSet { saveDecks() }
+    }
+
+    private let fileManager = FileManager.default
+    private var decksURL: URL {
+        fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("decks.json")
+    }
+
     public init(cards: [Card]) {
         self.allCards = cards
-        self.decks = [PlayerDeck(name: "Starter Deck", cardIDs: cards.prefix(10).map { $0.id })]
+        if let saved = loadDecks() {
+            self.decks = saved
+        } else {
+            self.decks = [PlayerDeck(name: "Starter Deck", cardIDs: cards.prefix(10).map { $0.id })]
+            saveDecks()
+        }
+    }
+
+    public func saveDecks() {
+        do {
+            let data = try JSONEncoder().encode(decks)
+            try data.write(to: decksURL, options: .atomic)
+        } catch {
+            print("Failed to save decks: \(error)")
+        }
+    }
+
+    public func loadDecks() -> [PlayerDeck]? {
+        guard fileManager.fileExists(atPath: decksURL.path) else { return nil }
+        do {
+            let data = try Data(contentsOf: decksURL)
+            let decoded = try JSONDecoder().decode([PlayerDeck].self, from: data)
+            return decoded
+        } catch {
+            print("Failed to load decks: \(error)")
+            return nil
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add JSON persistence for player decks with FileManager
- Load saved decks before creating default starter deck

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project Epochs.xcodeproj -scheme Epochs -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68b2244b7d08832eb04fe092377f793f