### PR TITLE
Add tests for card decoding, deck validation, and sandbox flows

### DIFF
--- a/EpochsTests/EpochsTests.swift
+++ b/EpochsTests/EpochsTests.swift
@@ -9,9 +9,66 @@ import Testing
 @testable import Epochs
 
 struct EpochsTests {
-
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    private func loadCards() throws -> [Card] {
+        let testDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let rootDir = testDir.deletingLastPathComponent()
+        let url = rootDir.appendingPathComponent("Epochs/CardDB.json")
+        return try CardDB.load(from: url)
     }
-
+    
+    private func validate(deck: PlayerDeck) -> Bool {
+        let minimumDeckSize = 60
+        let maxCopiesPerCard = 4
+        guard deck.cardIDs.count >= minimumDeckSize else { return false }
+        let counts = Dictionary(grouping: deck.cardIDs, by: { $0 }).mapValues { $0.count }
+        return counts.values.allSatisfy { $0 <= maxCopiesPerCard }
+    }
+    
+    @Test func cardDecoding() throws {
+        let cards = try loadCards()
+        #expect(!cards.isEmpty)
+        #expect(cards.first?.name == "Apprentice Scholar")
+    }
+    
+    @Test func deckValidation() throws {
+        let cards = try loadCards()
+        let validDeck = PlayerDeck(name: "Valid", cardIDs: cards.prefix(60).map { $0.id })
+        #expect(validate(deck: validDeck))
+        let smallDeck = PlayerDeck(name: "Small", cardIDs: cards.prefix(59).map { $0.id })
+        #expect(!validate(deck: smallDeck))
+        var overCopies = cards.prefix(60).map { $0.id }
+        if let first = cards.first?.id {
+            for i in 0..<5 { overCopies[i] = first }
+        }
+        let tooManyCopiesDeck = PlayerDeck(name: "TooManyCopies", cardIDs: overCopies)
+        #expect(!validate(deck: tooManyCopiesDeck))
+    }
+    
+    @Test func rulesEngineInitialization() throws {
+        let cards = try loadCards()
+        let deck = PlayerDeck(name: "Deck", cardIDs: cards.prefix(60).map { $0.id })
+        let engine = RulesEngine(deck: deck, allCards: cards)
+        #expect(engine.state.hand.count == 7)
+        #expect(engine.state.library.count == deck.cardIDs.count - 7)
+        #expect(engine.state.ip == 20)
+    }
+    
+    @Test func rulesEnginePlayAndAttack() throws {
+        let cards = try loadCards()
+        guard let attacker = cards.first(where: { $0.stats != nil }) else {
+            return
+        }
+        let deck = PlayerDeck(name: "Attack", cardIDs: Array(repeating: attacker.id, count: 60))
+        let engine = RulesEngine(deck: deck, allCards: cards)
+        let card = engine.state.hand.first!
+        engine.play(card: card)
+        #expect(engine.state.battlefield.contains(card))
+        engine.nextPhase()
+        engine.nextPhase()
+        let initialIP = engine.state.ip
+        engine.attack(attacker: card, defender: nil)
+        if let stats = card.stats {
+            #expect(engine.state.ip == max(0, initialIP - stats.attack))
+        }
+    }
 }

--- a/EpochsUITests/EpochsUITests.swift
+++ b/EpochsUITests/EpochsUITests.swift
@@ -8,32 +8,49 @@
 import XCTest
 
 final class EpochsUITests: XCTestCase {
-
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-
-        // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
-
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
     }
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
+    override func tearDownWithError() throws { }
 
     @MainActor
-    func testExample() throws {
-        // UI tests must launch the application that they test.
+    func testDeckBuildingFlow() throws {
         let app = XCUIApplication()
         app.launch()
 
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        app.tabBars.buttons["Deck Builder"].tap()
+        XCTAssertTrue(app.staticTexts["Deck invalid"].waitForExistence(timeout: 5))
+
+        let card = app.scrollViews.otherElements.staticTexts["Apprentice Scholar"].firstMatch
+        if card.exists { card.tap() }
+
+        XCTAssertTrue(app.staticTexts["Deck invalid"].exists)
+    }
+
+    @MainActor
+    func testSandboxPlayFlow() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        app.tabBars.buttons["Play (Sandbox)"].tap()
+        XCTAssertTrue(app.staticTexts["Influence Points: 20"].waitForExistence(timeout: 5))
+
+        let nextPhase = app.buttons["Next Phase"]
+        XCTAssertTrue(nextPhase.exists)
+        nextPhase.tap()
+        XCTAssertTrue(app.staticTexts["Influence Points: 21"].exists)
+
+        let draw = app.buttons["Draw"]
+        if draw.exists { draw.tap() }
+        let play = app.buttons["Play First From Hand"]
+        if play.exists { play.tap() }
+        let attack = app.buttons["Attack With First"]
+        if attack.exists { attack.tap() }
     }
 
     @MainActor
     func testLaunchPerformance() throws {
-        // This measures how long it takes to launch your application.
         measure(metrics: [XCTApplicationLaunchMetric()]) {
             XCUIApplication().launch()
         }


### PR DESCRIPTION
## Summary
- Add unit tests covering Card decoding, deck validation rules, and RulesEngine operations
- Script deck-building and sandbox play UI flows to verify buttons and labels

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -scheme Epochs -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b230163448832eb0d8f6ca61fdeec0